### PR TITLE
Potential fix for code scanning alert no. 15: Information exposure through an exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -390,7 +390,8 @@ def register():
         validate_password(password)
         validate_email(email)
     except ValueError as e:
-        return jsonify({"error": str(e)}), 400
+        logging.error(f"Validation error: {str(e)}")
+        return jsonify({"error": "Datos de registro inválidos."}), 400
 
     result = db.register(username, password, email)
     if "error" in result:


### PR DESCRIPTION
Potential fix for [https://github.com/nebis-db/nebis/security/code-scanning/15](https://github.com/nebis-db/nebis/security/code-scanning/15)

To fix the problem, we should avoid exposing the exception message directly to the user. Instead, we can log the detailed error message on the server and return a generic error message to the user. This approach ensures that developers can still access the detailed error information for debugging purposes without exposing it to external users.

- Modify the exception handling block to log the exception message using the `logging` module.
- Return a generic error message to the user instead of the specific exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
